### PR TITLE
Prevent modules/system/system.base.css from being excluded

### DIFF
--- a/sitenow/config.json
+++ b/sitenow/config.json
@@ -3,7 +3,7 @@
   "description": "{{Description}}",
   "bowerDir": "./bower_components",
   "css": {
-    "file" : "honors_radix.style.scss",
+    "file" : "{{machine_name}}.style.scss",
     "src": [
       "scss/**/*.scss"
     ],
@@ -14,7 +14,7 @@
     ]
   },
   "js": {
-    "file" : "honors_radix.script.js",
+    "file" : "{{machine_name}}.script.js",
     "src": [
       "assets/js/**/*.js"
     ],

--- a/sitenow/includes/css.inc
+++ b/sitenow/includes/css.inc
@@ -32,7 +32,6 @@ function {{machine_name}}_css_alter(&$css) {
     'modules/system/maintenance.css' => FALSE,
     'modules/system/system.css' => FALSE,
     'modules/system/system.admin.css' => FALSE,
-    'modules/system/system.base.css' => FALSE,
     'modules/system/system.maintenance.css' => FALSE,
     'modules/system/system.menus.css' => FALSE,
     'modules/system/system.messages.css' => FALSE,


### PR DESCRIPTION
Excluding this css causes some issues with the toolbar and other frontend components.