### PR TITLE
accessible brand colors.

### DIFF
--- a/sitenow/scss/base/variables/_bs_variables.scss
+++ b/sitenow/scss/base/variables/_bs_variables.scss
@@ -16,10 +16,10 @@ $gray-light:             lighten($gray-base, 46.7%) !default; // #777
 $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
 
 $brand-primary:         darken(#428bca, 6.5%) !default; // #337ab7
-$brand-success:         #5cb85c !default;
-$brand-info:            #5bc0de !default;
-$brand-warning:         #f0ad4e !default;
-$brand-danger:          #d9534f !default;
+$brand-success:         #358734 !default;
+$brand-info:            #9b479f !default;
+$brand-warning:         #B66008 !default;
+$brand-danger:          #D93D33 !default;
 
 
 //== Scaffolding
@@ -501,12 +501,12 @@ $jumbotron-heading-font-size:    ceil(($font-size-base * 4.5)) !default;
 //
 //## Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             #3c763d !default;
+$state-success-text:             #4B753C !default;
 $state-success-bg:               #dff0d8 !default;
 $state-success-border:           darken(adjust-hue($state-success-bg, -10), 5%) !default;
 
-$state-info-text:                #31708f !default;
-$state-info-bg:                  #d9edf7 !default;
+$state-info-text:                #9b479f !default;
+$state-info-bg:                  #F2E3F5 !default;
 $state-info-border:              darken(adjust-hue($state-info-bg, -10), 7%) !default;
 
 $state-warning-text:             #8a6d3b !default;


### PR DESCRIPTION
Accessible colors by default. Info as blue started to get so dark it looked like primary, so I went radical and went purple. All colors meet 4.5:1 I believe.

![screen shot 2016-10-19 at 2 30 14 pm](https://cloud.githubusercontent.com/assets/4663676/19534257/b3a9671e-9608-11e6-9881-c1f190b7b586.png)
![screen shot 2016-10-19 at 2 29 29 pm](https://cloud.githubusercontent.com/assets/4663676/19534267/b79d043e-9608-11e6-8579-29d3f52fe6c7.png)
![screen shot 2016-10-19 at 2 29 35 pm](https://cloud.githubusercontent.com/assets/4663676/19534272/bb3a8026-9608-11e6-8d98-cc8c4ea2d212.png)
![screen shot 2016-10-19 at 2 29 19 pm](https://cloud.githubusercontent.com/assets/4663676/19534275/bec27dde-9608-11e6-88a3-d3302992e311.png)
